### PR TITLE
Minor clean-up fix

### DIFF
--- a/csv.cpp
+++ b/csv.cpp
@@ -173,6 +173,7 @@ bool CSV::loadConfigFile(string configFile){
       this->sequence_color.push_back(configuration->readSequenceColor(this->section, i));
     }
     
+    delete configuration;
     syslog(LOG_DEBUG, "CSV %s: All configuration loaded", this->section.c_str());
     return true;
   }

--- a/json.cpp
+++ b/json.cpp
@@ -262,6 +262,7 @@ bool JSON::loadConfigFile(string configFile){
     
     this->graph_type = getGraphTypeFromString(configuration->readJSONType(this->section));
     
+    delete configuration;
     syslog(LOG_DEBUG, "JSON %s: All configuration loaded", this->section.c_str());
     return true;
   }

--- a/notify.cpp
+++ b/notify.cpp
@@ -161,6 +161,7 @@ bool NOTIFY::loadConfigFile(string configFile){
       this->http_identifier = configuration->readNotificationHttpIdentifier(this->section);
     }
     
+    delete configuration;
     syslog(LOG_DEBUG, "CSV %s: All configuration loaded", this->section.c_str());
     return true;
   }

--- a/serverstatus.cpp
+++ b/serverstatus.cpp
@@ -394,7 +394,7 @@ void startDaemon(const string &configFile) {
   }
   syslog(LOG_DEBUG, "Main Thread: All sys_stat objects created.");
 		
-
+  delete configuration;
   
   // the loop fires once every LOOP_TIME seconds
   int loopIteration = 0;


### PR DESCRIPTION
FIXED:
- memory is explicitly cleaned when config is finished loading (could
  easily multiply memory consumption due to multiple instances of a class)
